### PR TITLE
Updating ingress api version to newer kubernetes versions

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mlflow.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "mlflow.fullname" . }}-ingress

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mlflow.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- $servicePort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -32,8 +33,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+	    pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+	      service:
+	        name: {{ $fullName }}
+		port:
+		  number: {{ $servicePort }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
getting this on deploys with ingresses:\

> Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Ingress" in version "extensions/v1beta1"

Per https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ support was removed in 1.16